### PR TITLE
Ignore Environment-Specific Configuration Files

### DIFF
--- a/YaradiciEduAz/.gitignore
+++ b/YaradiciEduAz/.gitignore
@@ -10,4 +10,8 @@ obj/
 /node_modules
 /wwwroot/node_modules
 
+# Environment-Specific configuration files
+appsettings.Development.json
+appsettings.Production.json
+
 # End of https://www.toptal.com/developers/gitignore/api/dotnetcore

--- a/YaradiciEduAz/appsettings.Development.json
+++ b/YaradiciEduAz/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}


### PR DESCRIPTION
- Updated `.gitignore` to exclude `appsettings.Development.json` and `appsettings.Production.json` from version control.
- Removed `appsettings.Development.json` to prevent committing environment-specific settings.

This change ensures sensitive and environment-specific configurations are not tracked in Git.

fixes #8
